### PR TITLE
Support other Auth Modes

### DIFF
--- a/src/all/tachidesk/graphql/Login.graphql
+++ b/src/all/tachidesk/graphql/Login.graphql
@@ -1,0 +1,12 @@
+mutation Login($user: String!, $pass: String!) {
+    login(input: {username: $user, password: $pass}) {
+        accessToken
+        refreshToken
+    }
+}
+
+mutation RefreshToken($refreshToken: String!) {
+    refreshToken(input: {refreshToken: $refreshToken}) {
+        accessToken
+    }
+}

--- a/src/all/tachidesk/graphql/schema.graphqls
+++ b/src/all/tachidesk/graphql/schema.graphqls
@@ -1509,6 +1509,10 @@ type Mutation {
   updateLibraryManga(input: UpdateLibraryMangaInput!): UpdateLibraryMangaPayload!
 
   updateStop(input: UpdateStopInput!): UpdateStopPayload!
+
+  login(input: LoginInput!): LoginPayload!
+
+  refreshToken(input: RefreshTokenInput!): RefreshTokenPayload!
 }
 
 union Node = CategoryMetaType|CategoryType|ChapterMetaType|ChapterType|DownloadType|ExtensionType|GlobalMetaType|MangaMetaType|MangaType|PartialSettingsType|SettingsType|SourceMetaType|SourceType|TrackRecordType|TrackerType
@@ -2979,6 +2983,34 @@ type WebUIUpdateStatus {
   progress: Int!
 
   state: UpdateState!
+}
+
+input LoginInput {
+  clientMutationId: String
+
+  username: String!
+
+  password: String!
+}
+
+type LoginPayload {
+  clientMutationId: String
+
+  accessToken: String!
+
+  refreshToken: String!
+}
+
+input RefreshTokenInput {
+  clientMutationId: String
+
+  refreshToken: String!
+}
+
+type RefreshTokenPayload {
+  clientMutationId: String
+
+  accessToken: String!
 }
 
 type __Directive {

--- a/src/all/tachidesk/graphql/schema.graphqls
+++ b/src/all/tachidesk/graphql/schema.graphqls
@@ -1424,9 +1424,9 @@ type Mutation {
 
   deleteChapterMeta(input: DeleteChapterMetaInput!): DeleteChapterMetaPayload!
 
-  fetchChapterPages(input: FetchChapterPagesInput!): FetchChapterPagesPayload!
+  fetchChapterPages(input: FetchChapterPagesInput!): FetchChapterPagesPayload
 
-  fetchChapters(input: FetchChaptersInput!): FetchChaptersPayload!
+  fetchChapters(input: FetchChaptersInput!): FetchChaptersPayload
 
   setChapterMeta(input: SetChapterMetaInput!): SetChapterMetaPayload!
 
@@ -1470,7 +1470,7 @@ type Mutation {
 
   deleteMangaMeta(input: DeleteMangaMetaInput!): DeleteMangaMetaPayload!
 
-  fetchManga(input: FetchMangaInput!): FetchMangaPayload!
+  fetchManga(input: FetchMangaInput!): FetchMangaPayload
 
   setMangaMeta(input: SetMangaMetaInput!): SetMangaMetaPayload!
 

--- a/src/all/tachidesk/graphql/schema.graphqls
+++ b/src/all/tachidesk/graphql/schema.graphqls
@@ -9,15 +9,25 @@ type AboutServerPayload {
 
   name: String!
 
-  revision: String!
+  revision: String! @deprecated(reason: "The version includes the revision as the patch number")
 
   version: String!
 }
 
 type AboutWebUI {
-  channel: String!
+  channel: WebUIChannel!
 
   tag: String!
+}
+
+enum AuthMode {
+  NONE
+
+  BASIC_AUTH
+
+  SIMPLE_LOGIN
+
+  UI_LOGIN
 }
 
 enum BackupRestoreState {
@@ -30,6 +40,10 @@ enum BackupRestoreState {
   RESTORING_CATEGORIES
 
   RESTORING_MANGA
+
+  RESTORING_META
+
+  RESTORING_SETTINGS
 }
 
 type BackupRestoreStatus {
@@ -44,6 +58,11 @@ input BindTrackInput {
   clientMutationId: String
 
   mangaId: Int!
+
+  """
+  This will only work if the tracker of the track record supports private tracking
+  """
+  private: Boolean
 
   remoteId: LongString!
 
@@ -64,6 +83,10 @@ scalar Boolean
 input BooleanFilterInput {
   distinctFrom: Boolean
 
+  distinctFromAll: [Boolean!]
+
+  distinctFromAny: [Boolean!]
+
   equalTo: Boolean
 
   greaterThan: Boolean
@@ -81,6 +104,10 @@ input BooleanFilterInput {
   notDistinctFrom: Boolean
 
   notEqualTo: Boolean
+
+  notEqualToAll: [Boolean!]
+
+  notEqualToAny: [Boolean!]
 
   notIn: [Boolean!]
 }
@@ -115,6 +142,12 @@ input CategoryFilterInput {
   or: [CategoryFilterInput!]
 
   order: IntFilterInput
+}
+
+enum CategoryJobStatus {
+  UPDATING
+
+  SKIPPED
 }
 
 type CategoryMetaType implements MetaType {
@@ -153,6 +186,12 @@ enum CategoryOrderBy {
   ORDER
 }
 
+input CategoryOrderInput {
+  by: CategoryOrderBy!
+
+  byType: SortOrder
+}
+
 type CategoryType {
   default: Boolean!
 
@@ -169,6 +208,12 @@ type CategoryType {
   mangas: MangaNodeList!
 
   meta: [CategoryMetaType!]!
+}
+
+type CategoryUpdateType {
+  category: CategoryType!
+
+  status: CategoryJobStatus!
 }
 
 input ChapterConditionInput {
@@ -297,6 +342,12 @@ enum ChapterOrderBy {
   FETCHED_AT
 }
 
+input ChapterOrderInput {
+  by: ChapterOrderBy!
+
+  byType: SortOrder
+}
+
 type ChapterType {
   chapterNumber: Float!
 
@@ -346,11 +397,13 @@ type CheckBoxPreference {
 
   default: Boolean!
 
+  enabled: Boolean!
+
   key: String!
 
   summary: String
 
-  title: String!
+  title: String
 
   visible: Boolean!
 }
@@ -391,6 +444,14 @@ type ClearDownloaderPayload {
   clientMutationId: String
 
   downloadStatus: DownloadStatus!
+}
+
+input ConnectKoSyncAccountInput {
+  clientMutationId: String
+
+  password: String!
+
+  username: String!
 }
 
 input CreateBackupInput {
@@ -573,6 +634,10 @@ type DequeueChapterDownloadsPayload {
 input DoubleFilterInput {
   distinctFrom: Float
 
+  distinctFromAll: [Float!]
+
+  distinctFromAny: [Float!]
+
   equalTo: Float
 
   greaterThan: Float
@@ -591,7 +656,18 @@ input DoubleFilterInput {
 
   notEqualTo: Float
 
+  notEqualToAll: [Float!]
+
+  notEqualToAny: [Float!]
+
   notIn: [Float!]
+}
+
+input DownloadChangedInput {
+  """
+  Sets a max number of updates that can be contained in a download update message.Everything above this limit will be omitted and the "downloadStatus" should be re-fetched via the corresponding query. Due to the graphql subscription execution strategy not supporting batching for data loaders, the data loaders run into the n+1 problem, which can cause the server to get unresponsive until the status update has been handled. This is an issue e.g. when mass en- or dequeuing downloads.
+  """
+  maxUpdates: Int
 }
 
 type DownloadEdge implements Edge {
@@ -627,6 +703,8 @@ type DownloadStatus {
 }
 
 type DownloadType {
+  position: Int!
+
   progress: Float!
 
   state: DownloadState!
@@ -638,11 +716,56 @@ type DownloadType {
   manga: MangaType!
 }
 
+type DownloadUpdate {
+  download: DownloadType!
+
+  type: DownloadUpdateType!
+}
+
+enum DownloadUpdateType {
+  QUEUED
+
+  DEQUEUED
+
+  PAUSED
+
+  STOPPED
+
+  PROGRESS
+
+  FINISHED
+
+  ERROR
+
+  POSITION
+}
+
+type DownloadUpdates {
+  """
+  The current download queue at the time of sending initial message. Is null for all following messages
+  """
+  initial: [DownloadType!]
+
+  """
+  Indicates whether updates have been omitted based on the "maxUpdates" subscription variable. In case updates have been omitted, the "downloadStatus" query should be re-fetched.
+  """
+  omittedUpdates: Boolean!
+
+  state: DownloaderState!
+
+  updates: [DownloadUpdate!]!
+}
+
 enum DownloaderState {
   STARTED
 
   STOPPED
 }
+
+"""
+An ISO-8601 encoded duration string
+"""
+scalar Duration
 
 interface Edge {
   """
@@ -664,6 +787,8 @@ type EditTextPreference {
   dialogMessage: String
 
   dialogTitle: String
+
+  enabled: Boolean!
 
   key: String!
 
@@ -782,6 +907,12 @@ enum ExtensionOrderBy {
   APK_NAME
 }
 
+input ExtensionOrderInput {
+  by: ExtensionOrderBy!
+
+  byType: SortOrder
+}
+
 type ExtensionType {
   apkName: String!
 
@@ -814,6 +945,8 @@ input FetchChapterPagesInput {
   chapterId: Int!
 
   clientMutationId: String
+
+  format: String
 }
 
 type FetchChapterPagesPayload {
@@ -822,6 +955,8 @@ type FetchChapterPagesPayload {
   clientMutationId: String
 
   pages: [String!]!
+
+  syncConflict: SyncConflictInfoType
 }
 
 input FetchChaptersInput {
@@ -888,6 +1023,18 @@ enum FetchSourceMangaType {
   LATEST
 }
 
+input FetchTrackInput {
+  clientMutationId: String
+
+  recordId: Int!
+}
+
+type FetchTrackPayload {
+  clientMutationId: String
+
+  trackRecord: TrackRecordType!
+}
+
 union Filter = CheckBoxFilter|GroupFilter|HeaderFilter|SelectFilter|SeparatorFilter|SortFilter|TextFilter|TriStateFilter
 
 input FilterChangeInput {
@@ -914,6 +1061,10 @@ scalar Float
 input FloatFilterInput {
   distinctFrom: Float
 
+  distinctFromAll: [Float!]
+
+  distinctFromAny: [Float!]
+
   equalTo: Float
 
   greaterThan: Float
@@ -931,6 +1082,10 @@ input FloatFilterInput {
   notDistinctFrom: Float
 
   notEqualTo: Float
+
+  notEqualToAll: [Float!]
+
+  notEqualToAny: [Float!]
 
   notIn: [Float!]
 }
@@ -995,6 +1150,10 @@ scalar Int
 input IntFilterInput {
   distinctFrom: Int
 
+  distinctFromAll: [Int!]
+
+  distinctFromAny: [Int!]
+
   equalTo: Int
 
   greaterThan: Int
@@ -1013,17 +1172,74 @@ input IntFilterInput {
 
   notEqualTo: Int
 
+  notEqualToAll: [Int!]
+
+  notEqualToAny: [Int!]
+
   notIn: [Int!]
+}
+
+type KoSyncConnectPayload {
+  clientMutationId: String
+
+  message: String
+
+  settings: SettingsType!
+
+  success: Boolean!
+
+  username: String
+}
+
+type KoSyncStatusPayload {
+  isLoggedIn: Boolean!
+
+  username: String
+}
+
+enum KoreaderSyncChecksumMethod {
+  BINARY
+
+  FILENAME
+}
+
+enum KoreaderSyncStrategy {
+  PROMPT
+
+  SILENT
+
+  SEND
+
+  RECEIVE
+
+  DISABLED
 }
 
 type LastUpdateTimestampPayload {
   timestamp: LongString!
 }
 
+type LibraryUpdateStatus {
+  categoryUpdates: [CategoryUpdateType!]!
+
+  jobsInfo: UpdaterJobsInfoType!
+
+  mangaUpdates: [MangaUpdateType!]!
+}
+
+input LibraryUpdateStatusChangedInput {
+  """
+  Sets a max number of updates that can be contained in a updater update message.Everything above this limit will be omitted and the "updateStatus" should be re-fetched via the corresponding query. Due to the graphql subscription execution strategy not supporting batching for data loaders, the data loaders run into the n+1 problem, which can cause the server to get unresponsive until the status update has been handled. This is an issue e.g. when starting an update.
+  """
+  maxUpdates: Int
+}
+
 type ListPreference {
   currentValue: String
 
   default: String
+
+  enabled: Boolean!
 
   entries: [String!]!
 
@@ -1036,6 +1252,22 @@ type ListPreference {
   title: String
 
   visible: Boolean!
+}
+
+input LoginInput {
+  clientMutationId: String
+
+  password: String!
+
+  username: String!
+}
+
+type LoginPayload {
+  accessToken: String!
+
+  clientMutationId: String
+
+  refreshToken: String!
 }
 
 input LoginTrackerCredentialsInput {
@@ -1072,6 +1304,18 @@ type LoginTrackerOAuthPayload {
   tracker: TrackerType!
 }
 
+input LogoutKoSyncAccountInput {
+  clientMutationId: String
+}
+
+type LogoutKoSyncAccountPayload {
+  clientMutationId: String
+
+  settings: SettingsType!
+
+  success: Boolean!
+}
+
 input LogoutTrackerInput {
   clientMutationId: String
 
@@ -1088,6 +1332,10 @@ type LogoutTrackerPayload {
 
 input LongFilterInput {
   distinctFrom: LongString
+
+  distinctFromAll: [LongString!]
+
+  distinctFromAny: [LongString!]
 
   equalTo: LongString
 
@@ -1106,6 +1354,10 @@ input LongFilterInput {
   notDistinctFrom: LongString
 
   notEqualTo: LongString
+
+  notEqualToAll: [LongString!]
+
+  notEqualToAny: [LongString!]
 
   notIn: [LongString!]
 }
@@ -1199,6 +1451,18 @@ input MangaFilterInput {
   url: StringFilterInput
 }
 
+enum MangaJobStatus {
+  PENDING
+
+  RUNNING
+
+  COMPLETE
+
+  FAILED
+
+  SKIPPED
+}
+
 type MangaMetaType implements MetaType {
   key: String!
 
@@ -1237,6 +1501,12 @@ enum MangaOrderBy {
   LAST_FETCHED_AT
 }
 
+input MangaOrderInput {
+  by: MangaOrderBy!
+
+  byType: SortOrder
+}
+
 enum MangaStatus {
   UNKNOWN
 
@@ -1256,6 +1526,10 @@ enum MangaStatus {
 input MangaStatusFilterInput {
   distinctFrom: MangaStatus
 
+  distinctFromAll: [MangaStatus!]
+
+  distinctFromAny: [MangaStatus!]
+
   equalTo: MangaStatus
 
   greaterThan: MangaStatus
@@ -1273,6 +1547,10 @@ input MangaStatusFilterInput {
   notDistinctFrom: MangaStatus
 
   notEqualTo: MangaStatus
+
+  notEqualToAll: [MangaStatus!]
+
+  notEqualToAny: [MangaStatus!]
 
   notIn: [MangaStatus!]
 }
@@ -1316,6 +1594,8 @@ type MangaType {
 
   age: LongString
 
+  bookmarkCount: Int!
+
   categories: CategoryNodeList!
 
   chapters: ChapterNodeList!
@@ -1323,6 +1603,12 @@ type MangaType {
   chaptersAge: LongString
 
   downloadCount: Int!
+
+  firstUnreadChapter: ChapterType
+
+  hasDuplicateChapters: Boolean!
+
+  highestNumberedChapter: ChapterType
 
   lastReadChapter: ChapterType
 
@@ -1339,6 +1625,12 @@ type MangaType {
   trackRecords: TrackRecordNodeList!
 
   unreadCount: Int!
+}
+
+type MangaUpdateType {
+  manga: MangaType!
+
+  status: MangaJobStatus!
 }
 
 input MetaConditionInput {
@@ -1371,6 +1663,12 @@ enum MetaOrderBy {
   VALUE
 }
 
+input MetaOrderInput {
+  by: MetaOrderBy!
+
+  byType: SortOrder
+}
+
 interface MetaType {
   key: String!
 
@@ -1385,6 +1683,8 @@ type MultiSelectListPreference {
   dialogMessage: String
 
   dialogTitle: String
+
+  enabled: Boolean!
 
   entries: [String!]!
 
@@ -1404,97 +1704,103 @@ type Mutation {
 
   restoreBackup(input: RestoreBackupInput!): RestoreBackupPayload!
 
-  createCategory(input: CreateCategoryInput!): CreateCategoryPayload!
+  createCategory(input: CreateCategoryInput!): CreateCategoryPayload
 
-  deleteCategory(input: DeleteCategoryInput!): DeleteCategoryPayload!
+  deleteCategory(input: DeleteCategoryInput!): DeleteCategoryPayload
 
-  deleteCategoryMeta(input: DeleteCategoryMetaInput!): DeleteCategoryMetaPayload!
+  deleteCategoryMeta(input: DeleteCategoryMetaInput!): DeleteCategoryMetaPayload
 
-  setCategoryMeta(input: SetCategoryMetaInput!): SetCategoryMetaPayload!
+  setCategoryMeta(input: SetCategoryMetaInput!): SetCategoryMetaPayload
 
-  updateCategories(input: UpdateCategoriesInput!): UpdateCategoriesPayload!
+  updateCategories(input: UpdateCategoriesInput!): UpdateCategoriesPayload
 
-  updateCategory(input: UpdateCategoryInput!): UpdateCategoryPayload!
+  updateCategory(input: UpdateCategoryInput!): UpdateCategoryPayload
 
-  updateCategoryOrder(input: UpdateCategoryOrderInput!): UpdateCategoryOrderPayload!
+  updateCategoryOrder(input: UpdateCategoryOrderInput!): UpdateCategoryOrderPayload
 
-  updateMangaCategories(input: UpdateMangaCategoriesInput!): UpdateMangaCategoriesPayload!
+  updateMangaCategories(input: UpdateMangaCategoriesInput!): UpdateMangaCategoriesPayload
 
-  updateMangasCategories(input: UpdateMangasCategoriesInput!): UpdateMangasCategoriesPayload!
+  updateMangasCategories(input: UpdateMangasCategoriesInput!): UpdateMangasCategoriesPayload
 
-  deleteChapterMeta(input: DeleteChapterMetaInput!): DeleteChapterMetaPayload!
+  deleteChapterMeta(input: DeleteChapterMetaInput!): DeleteChapterMetaPayload
 
   fetchChapterPages(input: FetchChapterPagesInput!): FetchChapterPagesPayload
 
   fetchChapters(input: FetchChaptersInput!): FetchChaptersPayload
 
-  setChapterMeta(input: SetChapterMetaInput!): SetChapterMetaPayload!
+  setChapterMeta(input: SetChapterMetaInput!): SetChapterMetaPayload
 
-  updateChapter(input: UpdateChapterInput!): UpdateChapterPayload!
+  updateChapter(input: UpdateChapterInput!): UpdateChapterPayload
 
-  updateChapters(input: UpdateChaptersInput!): UpdateChaptersPayload!
+  updateChapters(input: UpdateChaptersInput!): UpdateChaptersPayload
 
-  clearDownloader(input: ClearDownloaderInput!): ClearDownloaderPayload!
+  clearDownloader(input: ClearDownloaderInput!): ClearDownloaderPayload
 
-  deleteDownloadedChapter(input: DeleteDownloadedChapterInput!): DeleteDownloadedChapterPayload!
+  deleteDownloadedChapter(input: DeleteDownloadedChapterInput!): DeleteDownloadedChapterPayload
 
-  deleteDownloadedChapters(input: DeleteDownloadedChaptersInput!): DeleteDownloadedChaptersPayload!
+  deleteDownloadedChapters(input: DeleteDownloadedChaptersInput!): DeleteDownloadedChaptersPayload
 
-  dequeueChapterDownload(input: DequeueChapterDownloadInput!): DequeueChapterDownloadPayload!
+  dequeueChapterDownload(input: DequeueChapterDownloadInput!): DequeueChapterDownloadPayload
 
-  dequeueChapterDownloads(input: DequeueChapterDownloadsInput!): DequeueChapterDownloadsPayload!
+  dequeueChapterDownloads(input: DequeueChapterDownloadsInput!): DequeueChapterDownloadsPayload
 
-  enqueueChapterDownload(input: EnqueueChapterDownloadInput!): EnqueueChapterDownloadPayload!
+  enqueueChapterDownload(input: EnqueueChapterDownloadInput!): EnqueueChapterDownloadPayload
 
-  enqueueChapterDownloads(input: EnqueueChapterDownloadsInput!): EnqueueChapterDownloadsPayload!
+  enqueueChapterDownloads(input: EnqueueChapterDownloadsInput!): EnqueueChapterDownloadsPayload
 
-  reorderChapterDownload(input: ReorderChapterDownloadInput!): ReorderChapterDownloadPayload!
+  reorderChapterDownload(input: ReorderChapterDownloadInput!): ReorderChapterDownloadPayload
 
-  startDownloader(input: StartDownloaderInput!): StartDownloaderPayload!
+  startDownloader(input: StartDownloaderInput!): StartDownloaderPayload
 
-  stopDownloader(input: StopDownloaderInput!): StopDownloaderPayload!
+  stopDownloader(input: StopDownloaderInput!): StopDownloaderPayload
 
-  fetchExtensions(input: FetchExtensionsInput!): FetchExtensionsPayload!
+  fetchExtensions(input: FetchExtensionsInput!): FetchExtensionsPayload
 
-  installExternalExtension(input: InstallExternalExtensionInput!): InstallExternalExtensionPayload!
+  installExternalExtension(input: InstallExternalExtensionInput!): InstallExternalExtensionPayload
 
-  updateExtension(input: UpdateExtensionInput!): UpdateExtensionPayload!
+  updateExtension(input: UpdateExtensionInput!): UpdateExtensionPayload
 
-  updateExtensions(input: UpdateExtensionsInput!): UpdateExtensionsPayload!
+  updateExtensions(input: UpdateExtensionsInput!): UpdateExtensionsPayload
 
   clearCachedImages(input: ClearCachedImagesInput!): ClearCachedImagesPayload!
 
-  resetWebUIUpdateStatus: WebUIUpdateStatus!
+  resetWebUIUpdateStatus: WebUIUpdateStatus
 
-  updateWebUI(input: WebUIUpdateInput!): WebUIUpdatePayload!
+  updateWebUI(input: WebUIUpdateInput!): WebUIUpdatePayload
 
-  deleteMangaMeta(input: DeleteMangaMetaInput!): DeleteMangaMetaPayload!
+  connectKoSyncAccount(input: ConnectKoSyncAccountInput!): KoSyncConnectPayload!
+
+  logoutKoSyncAccount(input: LogoutKoSyncAccountInput!): LogoutKoSyncAccountPayload!
+
+  deleteMangaMeta(input: DeleteMangaMetaInput!): DeleteMangaMetaPayload
 
   fetchManga(input: FetchMangaInput!): FetchMangaPayload
 
-  setMangaMeta(input: SetMangaMetaInput!): SetMangaMetaPayload!
+  setMangaMeta(input: SetMangaMetaInput!): SetMangaMetaPayload
 
-  updateManga(input: UpdateMangaInput!): UpdateMangaPayload!
+  updateManga(input: UpdateMangaInput!): UpdateMangaPayload
 
-  updateMangas(input: UpdateMangasInput!): UpdateMangasPayload!
+  updateMangas(input: UpdateMangasInput!): UpdateMangasPayload
 
-  deleteGlobalMeta(input: DeleteGlobalMetaInput!): DeleteGlobalMetaPayload!
+  deleteGlobalMeta(input: DeleteGlobalMetaInput!): DeleteGlobalMetaPayload
 
-  setGlobalMeta(input: SetGlobalMetaInput!): SetGlobalMetaPayload!
+  setGlobalMeta(input: SetGlobalMetaInput!): SetGlobalMetaPayload
 
   resetSettings(input: ResetSettingsInput!): ResetSettingsPayload!
 
   setSettings(input: SetSettingsInput!): SetSettingsPayload!
 
-  deleteSourceMeta(input: DeleteSourceMetaInput!): DeleteSourceMetaPayload!
+  deleteSourceMeta(input: DeleteSourceMetaInput!): DeleteSourceMetaPayload
 
-  fetchSourceManga(input: FetchSourceMangaInput!): FetchSourceMangaPayload!
+  fetchSourceManga(input: FetchSourceMangaInput!): FetchSourceMangaPayload
 
-  setSourceMeta(input: SetSourceMetaInput!): SetSourceMetaPayload!
+  setSourceMeta(input: SetSourceMetaInput!): SetSourceMetaPayload
 
-  updateSourcePreference(input: UpdateSourcePreferenceInput!): UpdateSourcePreferencePayload!
+  updateSourcePreference(input: UpdateSourcePreferenceInput!): UpdateSourcePreferencePayload
 
   bindTrack(input: BindTrackInput!): BindTrackPayload!
+
+  fetchTrack(input: FetchTrackInput!): FetchTrackPayload!
 
   loginTrackerCredentials(input: LoginTrackerCredentialsInput!): LoginTrackerCredentialsPayload!
 
@@ -1502,11 +1808,17 @@ type Mutation {
 
   logoutTracker(input: LogoutTrackerInput!): LogoutTrackerPayload!
 
+  trackProgress(input: TrackProgressInput!): TrackProgressPayload
+
+  unbindTrack(input: UnbindTrackInput!): UnbindTrackPayload!
+
   updateTrack(input: UpdateTrackInput!): UpdateTrackPayload!
 
-  updateCategoryManga(input: UpdateCategoryMangaInput!): UpdateCategoryMangaPayload!
+  updateCategoryManga(input: UpdateCategoryMangaInput!): UpdateCategoryMangaPayload
 
-  updateLibraryManga(input: UpdateLibraryMangaInput!): UpdateLibraryMangaPayload!
+  updateLibrary(input: UpdateLibraryInput!): UpdateLibraryPayload
+
+  updateLibraryManga(input: UpdateLibraryMangaInput!): UpdateLibraryMangaPayload
 
   updateStop(input: UpdateStopInput!): UpdateStopPayload!
 
@@ -1515,7 +1827,7 @@ type Mutation {
   refreshToken(input: RefreshTokenInput!): RefreshTokenPayload!
 }
 
-union Node = CategoryMetaType|CategoryType|ChapterMetaType|ChapterType|DownloadType|ExtensionType|GlobalMetaType|MangaMetaType|MangaType|PartialSettingsType|SettingsType|SourceMetaType|SourceType|TrackRecordType|TrackerType
+union Node = CategoryMetaType|CategoryType|ChapterMetaType|ChapterType|DownloadType|DownloadUpdate|ExtensionType|GlobalMetaType|MangaMetaType|MangaType|PartialSettingsType|SettingsType|SourceMetaType|SourceType|TrackRecordType|TrackerType
 
 interface NodeList {
   """
@@ -1562,7 +1874,15 @@ type PageInfo {
 }
 
 type PartialSettingsType implements Settings {
+  authMode: AuthMode
+
+  authPassword: String
+
+  authUsername: String
+
   autoDownloadAheadLimit: Int @deprecated(reason: "Replaced with autoDownloadNewChaptersLimit, replace with autoDownloadNewChaptersLimit")
+
+  autoDownloadIgnoreReUploads: Boolean
 
   autoDownloadNewChapters: Boolean
 
@@ -1576,15 +1896,17 @@ type PartialSettingsType implements Settings {
 
   backupTime: String
 
-  basicAuthEnabled: Boolean
+  basicAuthEnabled: Boolean @deprecated(reason: "Removed - prefer authMode")
 
-  basicAuthPassword: String
+  basicAuthPassword: String @deprecated(reason: "Removed - prefer authPassword")
 
-  basicAuthUsername: String
+  basicAuthUsername: String @deprecated(reason: "Removed - prefer authUsername")
 
   debugLogsEnabled: Boolean
 
   downloadAsCbz: Boolean
+
+  downloadConversions: [SettingsDownloadConversionType!]
 
   downloadsPath: String
 
@@ -1600,6 +1922,8 @@ type PartialSettingsType implements Settings {
 
   extensionRepos: [String!]
 
+  flareSolverrAsResponseFallback: Boolean
+
   flareSolverrEnabled: Boolean
 
   flareSolverrSessionName: String
@@ -1612,15 +1936,55 @@ type PartialSettingsType implements Settings {
 
   globalUpdateInterval: Float
 
-  gqlDebugLogsEnabled: Boolean
+  gqlDebugLogsEnabled: Boolean @deprecated(reason: "Removed - does not do anything")
 
   initialOpenInBrowserEnabled: Boolean
 
   ip: String
 
+  jwtAudience: String
+
+  jwtRefreshExpiry: Duration
+
+  jwtTokenExpiry: Duration
+
+  koreaderSyncChecksumMethod: KoreaderSyncChecksumMethod
+
+  koreaderSyncDeviceId: String
+
+  koreaderSyncPercentageTolerance: Float
+
+  koreaderSyncServerUrl: String
+
+  koreaderSyncStrategy: KoreaderSyncStrategy
+
+  koreaderSyncUserkey: String
+
+  koreaderSyncUsername: String
+
   localSourcePath: String
 
+  maxLogFileSize: String
+
+  maxLogFiles: Int
+
+  maxLogFolderSize: String
+
   maxSourcesInParallel: Int
+
+  opdsChapterSortOrder: SortOrder
+
+  opdsEnablePageReadProgress: Boolean
+
+  opdsItemsPerPage: Int
+
+  opdsMarkAsReadOnDownload: Boolean
+
+  opdsShowOnlyDownloadedChapters: Boolean
+
+  opdsShowOnlyUnreadChapters: Boolean
+
+  opdsUseBinaryFileSizes: Boolean
 
   port: Int
 
@@ -1650,7 +2014,15 @@ type PartialSettingsType implements Settings {
 }
 
 input PartialSettingsTypeInput {
+  authMode: AuthMode
+
+  authPassword: String
+
+  authUsername: String
+
   autoDownloadAheadLimit: Int @deprecated(reason: "Replaced with autoDownloadNewChaptersLimit, replace with autoDownloadNewChaptersLimit")
+
+  autoDownloadIgnoreReUploads: Boolean
 
   autoDownloadNewChapters: Boolean
 
@@ -1664,15 +2036,17 @@ input PartialSettingsTypeInput {
 
   backupTime: String
 
-  basicAuthEnabled: Boolean
+  basicAuthEnabled: Boolean @deprecated(reason: "Removed - prefer authMode")
 
-  basicAuthPassword: String
+  basicAuthPassword: String @deprecated(reason: "Removed - prefer authPassword")
 
-  basicAuthUsername: String
+  basicAuthUsername: String @deprecated(reason: "Removed - prefer authUsername")
 
   debugLogsEnabled: Boolean
 
   downloadAsCbz: Boolean
+
+  downloadConversions: [SettingsDownloadConversionTypeInput!]
 
   downloadsPath: String
 
@@ -1688,6 +2062,8 @@ input PartialSettingsTypeInput {
 
   extensionRepos: [String!]
 
+  flareSolverrAsResponseFallback: Boolean
+
   flareSolverrEnabled: Boolean
 
   flareSolverrSessionName: String
@@ -1700,15 +2076,55 @@ input PartialSettingsTypeInput {
 
   globalUpdateInterval: Float
 
-  gqlDebugLogsEnabled: Boolean
+  gqlDebugLogsEnabled: Boolean @deprecated(reason: "Removed - does not do anything")
 
   initialOpenInBrowserEnabled: Boolean
 
   ip: String
 
+  jwtAudience: String
+
+  jwtRefreshExpiry: Duration
+
+  jwtTokenExpiry: Duration
+
+  koreaderSyncChecksumMethod: KoreaderSyncChecksumMethod
+
+  koreaderSyncDeviceId: String
+
+  koreaderSyncPercentageTolerance: Float
+
+  koreaderSyncServerUrl: String
+
+  koreaderSyncStrategy: KoreaderSyncStrategy
+
+  koreaderSyncUserkey: String
+
+  koreaderSyncUsername: String
+
   localSourcePath: String
 
+  maxLogFileSize: String
+
+  maxLogFiles: Int
+
+  maxLogFolderSize: String
+
   maxSourcesInParallel: Int
+
+  opdsChapterSortOrder: SortOrder
+
+  opdsEnablePageReadProgress: Boolean
+
+  opdsItemsPerPage: Int
+
+  opdsMarkAsReadOnDownload: Boolean
+
+  opdsShowOnlyDownloadedChapters: Boolean
+
+  opdsShowOnlyUnreadChapters: Boolean
+
+  opdsUseBinaryFileSizes: Boolean
 
   port: Int
 
@@ -1744,19 +2160,19 @@ type Query {
 
   validateBackup(input: ValidateBackupInput!): ValidateBackupResult!
 
-  categories(condition: CategoryConditionInput, filter: CategoryFilterInput, orderBy: CategoryOrderBy, orderByType: SortOrder, before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): CategoryNodeList!
+  categories(condition: CategoryConditionInput, filter: CategoryFilterInput, orderBy: CategoryOrderBy, orderByType: SortOrder, order: [CategoryOrderInput!], before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): CategoryNodeList!
 
   category(id: Int!): CategoryType!
 
   chapter(id: Int!): ChapterType!
 
-  chapters(condition: ChapterConditionInput, filter: ChapterFilterInput, orderBy: ChapterOrderBy, orderByType: SortOrder, before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): ChapterNodeList!
+  chapters(condition: ChapterConditionInput, filter: ChapterFilterInput, orderBy: ChapterOrderBy, orderByType: SortOrder, order: [ChapterOrderInput!], before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): ChapterNodeList!
 
   downloadStatus: DownloadStatus!
 
   extension(pkgName: String!): ExtensionType!
 
-  extensions(condition: ExtensionConditionInput, filter: ExtensionFilterInput, orderBy: ExtensionOrderBy, orderByType: SortOrder, before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): ExtensionNodeList!
+  extensions(condition: ExtensionConditionInput, filter: ExtensionFilterInput, orderBy: ExtensionOrderBy, orderByType: SortOrder, order: [ExtensionOrderInput!], before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): ExtensionNodeList!
 
   aboutServer: AboutServerPayload!
 
@@ -1768,33 +2184,49 @@ type Query {
 
   getWebUIUpdateStatus: WebUIUpdateStatus!
 
+  koSyncStatus: KoSyncStatusPayload!
+
   manga(id: Int!): MangaType!
 
-  mangas(condition: MangaConditionInput, filter: MangaFilterInput, orderBy: MangaOrderBy, orderByType: SortOrder, before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): MangaNodeList!
+  mangas(condition: MangaConditionInput, filter: MangaFilterInput, orderBy: MangaOrderBy, orderByType: SortOrder, order: [MangaOrderInput!], before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): MangaNodeList!
 
   meta(key: String!): GlobalMetaType!
 
-  metas(condition: MetaConditionInput, filter: MetaFilterInput, orderBy: MetaOrderBy, orderByType: SortOrder, before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): GlobalMetaNodeList!
+  metas(condition: MetaConditionInput, filter: MetaFilterInput, orderBy: MetaOrderBy, orderByType: SortOrder, order: [MetaOrderInput!], before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): GlobalMetaNodeList!
 
   settings: SettingsType!
 
   source(id: LongString!): SourceType!
 
-  sources(condition: SourceConditionInput, filter: SourceFilterInput, orderBy: SourceOrderBy, orderByType: SortOrder, before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): SourceNodeList!
+  sources(condition: SourceConditionInput, filter: SourceFilterInput, orderBy: SourceOrderBy, orderByType: SortOrder, order: [SourceOrderInput!], before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): SourceNodeList!
 
   searchTracker(input: SearchTrackerInput!): SearchTrackerPayload!
 
   trackRecord(id: Int!): TrackRecordType!
 
-  trackRecords(condition: TrackRecordConditionInput, filter: TrackRecordFilterInput, orderBy: TrackRecordOrderBy, orderByType: SortOrder, before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): TrackRecordNodeList!
+  trackRecords(condition: TrackRecordConditionInput, filter: TrackRecordFilterInput, orderBy: TrackRecordOrderBy, orderByType: SortOrder, order: [TrackRecordOrderInput!], before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): TrackRecordNodeList!
 
   tracker(id: Int!): TrackerType!
 
-  trackers(condition: TrackerConditionInput, orderBy: TrackerOrderBy, orderByType: SortOrder, before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): TrackerNodeList!
+  trackers(condition: TrackerConditionInput, orderBy: TrackerOrderBy, orderByType: SortOrder, order: [TrackerOrderInput!], before: Cursor, after: Cursor, first: Int, last: Int, offset: Int): TrackerNodeList!
 
   lastUpdateTimestamp: LastUpdateTimestampPayload!
 
-  updateStatus: UpdateStatus!
+  libraryUpdateStatus: LibraryUpdateStatus!
+
+  updateStatus: UpdateStatus! @deprecated(reason: "Replaced with libraryUpdateStatus, replace with libraryUpdateStatus")
+}
+
+input RefreshTokenInput {
+  clientMutationId: String
+
+  refreshToken: String!
+}
+
+type RefreshTokenPayload {
+  accessToken: String!
+
+  clientMutationId: String
 }
 
 input ReorderChapterDownloadInput {
@@ -1930,7 +2362,15 @@ type SetSourceMetaPayload {
 }
 
 interface Settings {
+  authMode: AuthMode
+
+  authPassword: String
+
+  authUsername: String
+
   autoDownloadAheadLimit: Int @deprecated(reason: "Replaced with autoDownloadNewChaptersLimit, replace with autoDownloadNewChaptersLimit")
+
+  autoDownloadIgnoreReUploads: Boolean
 
   autoDownloadNewChapters: Boolean
 
@@ -1944,15 +2384,17 @@ interface Settings {
 
   backupTime: String
 
-  basicAuthEnabled: Boolean
+  basicAuthEnabled: Boolean @deprecated(reason: "Removed - prefer authMode")
 
-  basicAuthPassword: String
+  basicAuthPassword: String @deprecated(reason: "Removed - prefer authPassword")
 
-  basicAuthUsername: String
+  basicAuthUsername: String @deprecated(reason: "Removed - prefer authUsername")
 
   debugLogsEnabled: Boolean
 
   downloadAsCbz: Boolean
+
+  downloadConversions: [SettingsDownloadConversion!]
 
   downloadsPath: String
 
@@ -1968,6 +2410,8 @@ interface Settings {
 
   extensionRepos: [String!]
 
+  flareSolverrAsResponseFallback: Boolean
+
   flareSolverrEnabled: Boolean
 
   flareSolverrSessionName: String
@@ -1980,15 +2424,55 @@ interface Settings {
 
   globalUpdateInterval: Float
 
-  gqlDebugLogsEnabled: Boolean
+  gqlDebugLogsEnabled: Boolean @deprecated(reason: "Removed - does not do anything")
 
   initialOpenInBrowserEnabled: Boolean
 
   ip: String
 
+  jwtAudience: String
+
+  jwtRefreshExpiry: Duration
+
+  jwtTokenExpiry: Duration
+
+  koreaderSyncChecksumMethod: KoreaderSyncChecksumMethod
+
+  koreaderSyncDeviceId: String
+
+  koreaderSyncPercentageTolerance: Float
+
+  koreaderSyncServerUrl: String
+
+  koreaderSyncStrategy: KoreaderSyncStrategy
+
+  koreaderSyncUserkey: String
+
+  koreaderSyncUsername: String
+
   localSourcePath: String
 
+  maxLogFileSize: String
+
+  maxLogFiles: Int
+
+  maxLogFolderSize: String
+
   maxSourcesInParallel: Int
+
+  opdsChapterSortOrder: SortOrder
+
+  opdsEnablePageReadProgress: Boolean
+
+  opdsItemsPerPage: Int
+
+  opdsMarkAsReadOnDownload: Boolean
+
+  opdsShowOnlyDownloadedChapters: Boolean
+
+  opdsShowOnlyUnreadChapters: Boolean
+
+  opdsUseBinaryFileSizes: Boolean
 
   port: Int
 
@@ -2017,8 +2501,40 @@ interface Settings {
   webUIUpdateCheckInterval: Float
 }
 
+interface SettingsDownloadConversion {
+  compressionLevel: Float
+
+  mimeType: String!
+
+  target: String!
+}
+
+type SettingsDownloadConversionType implements SettingsDownloadConversion {
+  compressionLevel: Float
+
+  mimeType: String!
+
+  target: String!
+}
+
+input SettingsDownloadConversionTypeInput {
+  compressionLevel: Float
+
+  mimeType: String!
+
+  target: String!
+}
+
 type SettingsType implements Settings {
+  authMode: AuthMode!
+
+  authPassword: String!
+
+  authUsername: String!
+
   autoDownloadAheadLimit: Int! @deprecated(reason: "Replaced with autoDownloadNewChaptersLimit, replace with autoDownloadNewChaptersLimit")
+
+  autoDownloadIgnoreReUploads: Boolean!
 
   autoDownloadNewChapters: Boolean!
 
@@ -2032,15 +2548,17 @@ type SettingsType implements Settings {
 
   backupTime: String!
 
-  basicAuthEnabled: Boolean!
+  basicAuthEnabled: Boolean! @deprecated(reason: "Removed - prefer authMode")
 
-  basicAuthPassword: String!
+  basicAuthPassword: String! @deprecated(reason: "Removed - prefer authPassword")
 
-  basicAuthUsername: String!
+  basicAuthUsername: String! @deprecated(reason: "Removed - prefer authUsername")
 
   debugLogsEnabled: Boolean!
 
   downloadAsCbz: Boolean!
+
+  downloadConversions: [SettingsDownloadConversionType!]!
 
   downloadsPath: String!
 
@@ -2056,6 +2574,8 @@ type SettingsType implements Settings {
 
   extensionRepos: [String!]!
 
+  flareSolverrAsResponseFallback: Boolean!
+
   flareSolverrEnabled: Boolean!
 
   flareSolverrSessionName: String!
@@ -2068,15 +2588,55 @@ type SettingsType implements Settings {
 
   globalUpdateInterval: Float!
 
-  gqlDebugLogsEnabled: Boolean!
+  gqlDebugLogsEnabled: Boolean! @deprecated(reason: "Removed - does not do anything")
 
   initialOpenInBrowserEnabled: Boolean!
 
   ip: String!
 
+  jwtAudience: String!
+
+  jwtRefreshExpiry: Duration!
+
+  jwtTokenExpiry: Duration!
+
+  koreaderSyncChecksumMethod: KoreaderSyncChecksumMethod!
+
+  koreaderSyncDeviceId: String!
+
+  koreaderSyncPercentageTolerance: Float!
+
+  koreaderSyncServerUrl: String!
+
+  koreaderSyncStrategy: KoreaderSyncStrategy!
+
+  koreaderSyncUserkey: String!
+
+  koreaderSyncUsername: String!
+
   localSourcePath: String!
 
+  maxLogFileSize: String!
+
+  maxLogFiles: Int!
+
+  maxLogFolderSize: String!
+
   maxSourcesInParallel: Int!
+
+  opdsChapterSortOrder: SortOrder!
+
+  opdsEnablePageReadProgress: Boolean!
+
+  opdsItemsPerPage: Int!
+
+  opdsMarkAsReadOnDownload: Boolean!
+
+  opdsShowOnlyDownloadedChapters: Boolean!
+
+  opdsShowOnlyUnreadChapters: Boolean!
+
+  opdsUseBinaryFileSizes: Boolean!
 
   port: Int!
 
@@ -2207,6 +2767,12 @@ enum SourceOrderBy {
   LANG
 }
 
+input SourceOrderInput {
+  by: SourceOrderBy!
+
+  byType: SortOrder
+}
+
 input SourcePreferenceChangeInput {
   checkBoxState: Boolean
 
@@ -2222,6 +2788,8 @@ input SourcePreferenceChangeInput {
 }
 
 type SourceType {
+  baseUrl: String
+
   displayName: String!
 
   iconUrl: String!
@@ -2277,11 +2845,27 @@ scalar String
 input StringFilterInput {
   distinctFrom: String
 
+  distinctFromAll: [String!]
+
+  distinctFromAny: [String!]
+
   distinctFromInsensitive: String
+
+  distinctFromInsensitiveAll: [String!]
+
+  distinctFromInsensitiveAny: [String!]
 
   endsWith: String
 
+  endsWithAll: [String!]
+
+  endsWithAny: [String!]
+
   endsWithInsensitive: String
+
+  endsWithInsensitiveAll: [String!]
+
+  endsWithInsensitiveAny: [String!]
 
   equalTo: String
 
@@ -2299,7 +2883,15 @@ input StringFilterInput {
 
   includes: String
 
+  includesAll: [String!]
+
+  includesAny: [String!]
+
   includesInsensitive: String
+
+  includesInsensitiveAll: [String!]
+
+  includesInsensitiveAny: [String!]
 
   isNull: Boolean
 
@@ -2313,7 +2905,15 @@ input StringFilterInput {
 
   like: String
 
+  likeAll: [String!]
+
+  likeAny: [String!]
+
   likeInsensitive: String
+
+  likeInsensitiveAll: [String!]
+
+  likeInsensitiveAny: [String!]
 
   notDistinctFrom: String
 
@@ -2321,9 +2921,21 @@ input StringFilterInput {
 
   notEndsWith: String
 
+  notEndsWithAll: [String!]
+
+  notEndsWithAny: [String!]
+
   notEndsWithInsensitive: String
 
+  notEndsWithInsensitiveAll: [String!]
+
+  notEndsWithInsensitiveAny: [String!]
+
   notEqualTo: String
+
+  notEqualToAll: [String!]
+
+  notEqualToAny: [String!]
 
   notIn: [String!]
 
@@ -2331,27 +2943,63 @@ input StringFilterInput {
 
   notIncludes: String
 
+  notIncludesAll: [String!]
+
+  notIncludesAny: [String!]
+
   notIncludesInsensitive: String
+
+  notIncludesInsensitiveAll: [String!]
+
+  notIncludesInsensitiveAny: [String!]
 
   notLike: String
 
+  notLikeAll: [String!]
+
+  notLikeAny: [String!]
+
   notLikeInsensitive: String
+
+  notLikeInsensitiveAll: [String!]
+
+  notLikeInsensitiveAny: [String!]
 
   notStartsWith: String
 
+  notStartsWithAll: [String!]
+
+  notStartsWithAny: [String!]
+
   notStartsWithInsensitive: String
+
+  notStartsWithInsensitiveAll: [String!]
+
+  notStartsWithInsensitiveAny: [String!]
 
   startsWith: String
 
+  startsWithAll: [String!]
+
+  startsWithAny: [String!]
+
   startsWithInsensitive: String
+
+  startsWithInsensitiveAll: [String!]
+
+  startsWithInsensitiveAny: [String!]
 }
 
 type Subscription {
-  downloadChanged: DownloadStatus!
+  downloadChanged: DownloadStatus! @deprecated(reason: "Replaced with downloadStatusChanged, replace with downloadStatusChanged(input)")
+
+  downloadStatusChanged(input: DownloadChangedInput!): DownloadUpdates!
 
   webUIUpdateStatusChange: WebUIUpdateStatus!
 
-  updateStatusChanged: UpdateStatus!
+  libraryUpdateStatusChanged(input: LibraryUpdateStatusChangedInput!): UpdaterUpdates!
+
+  updateStatusChanged: UpdateStatus! @deprecated(reason: "Replaced with updates, replace with updates(input)")
 }
 
 type SwitchPreference {
@@ -2359,19 +3007,39 @@ type SwitchPreference {
 
   default: Boolean!
 
+  enabled: Boolean!
+
   key: String!
 
   summary: String
 
-  title: String!
+  title: String
 
   visible: Boolean!
+}
+
+type SyncConflictInfoType {
+  deviceName: String!
+
+  remotePage: Int!
 }
 
 type TextFilter {
   default: String!
 
   name: String!
+}
+
+input TrackProgressInput {
+  clientMutationId: String
+
+  mangaId: Int!
+}
+
+type TrackProgressPayload {
+  clientMutationId: String
+
+  trackRecords: [TrackRecordType!]!
 }
 
 input TrackRecordConditionInput {
@@ -2384,6 +3052,8 @@ input TrackRecordConditionInput {
   libraryId: LongString
 
   mangaId: Int
+
+  private: Boolean
 
   remoteId: LongString
 
@@ -2424,6 +3094,8 @@ input TrackRecordFilterInput {
   not: TrackRecordFilterInput
 
   or: [TrackRecordFilterInput!]
+
+  private: BooleanFilterInput
 
   remoteId: LongFilterInput
 
@@ -2472,6 +3144,14 @@ enum TrackRecordOrderBy {
   START_DATE
 
   FINISH_DATE
+
+  PRIVATE
+}
+
+input TrackRecordOrderInput {
+  by: TrackRecordOrderBy!
+
+  byType: SortOrder
 }
 
 type TrackRecordType {
@@ -2484,6 +3164,8 @@ type TrackRecordType {
   libraryId: LongString
 
   mangaId: Int!
+
+  private: Boolean!
 
   remoteId: LongString!
 
@@ -2511,7 +3193,15 @@ type TrackRecordType {
 type TrackSearchType {
   coverUrl: String!
 
+  finishedReadingDate: LongString!
+
   id: Int!
+
+  lastChapterRead: Float!
+
+  libraryId: LongString
+
+  private: Boolean!
 
   publishingStatus: String!
 
@@ -2519,7 +3209,13 @@ type TrackSearchType {
 
   remoteId: LongString!
 
+  score: Float!
+
   startDate: String!
+
+  startedReadingDate: LongString!
+
+  status: Int!
 
   summary: String!
 
@@ -2530,6 +3226,8 @@ type TrackSearchType {
   trackerId: Int!
 
   trackingUrl: String!
+
+  displayScore: String!
 
   tracker: TrackerType!
 }
@@ -2574,6 +3272,12 @@ enum TrackerOrderBy {
   IS_LOGGED_IN
 }
 
+input TrackerOrderInput {
+  by: TrackerOrderBy!
+
+  byType: SortOrder
+}
+
 type TrackerType {
   authUrl: String
 
@@ -2584,6 +3288,12 @@ type TrackerType {
   isLoggedIn: Boolean!
 
   name: String!
+
+  supportsPrivateTracking: Boolean!
+
+  supportsReadingDates: Boolean!
+
+  supportsTrackDeletion: Boolean!
 
   isTokenExpired: Boolean!
 
@@ -2606,6 +3316,23 @@ type TriStateFilter {
   default: TriState!
 
   name: String!
+}
+
+input UnbindTrackInput {
+  clientMutationId: String
+
+  """
+  This will only work if the tracker of the track record supports deleting tracks
+  """
+  deleteRemoteTrack: Boolean
+
+  recordId: Int!
+}
+
+type UnbindTrackPayload {
+  clientMutationId: String
+
+  trackRecord: TrackRecordType
 }
 
 input UpdateCategoriesInput {
@@ -2744,6 +3471,12 @@ type UpdateExtensionsPayload {
   extensions: [ExtensionType!]!
 }
 
+input UpdateLibraryInput {
+  categories: [Int!]
+
+  clientMutationId: String
+}
+
 input UpdateLibraryMangaInput {
   clientMutationId: String
 }
@@ -2752,6 +3485,12 @@ type UpdateLibraryMangaPayload {
   clientMutationId: String
 
   updateStatus: UpdateStatus!
+}
+
+type UpdateLibraryPayload {
+  clientMutationId: String
+
+  updateStatus: LibraryUpdateStatus!
 }
 
 input UpdateMangaCategoriesInput {
@@ -2891,25 +3630,66 @@ enum UpdateStrategy {
 input UpdateTrackInput {
   clientMutationId: String
 
+  """
+  This will only work if the tracker of the track record supports reading dates
+  """
   finishDate: LongString
 
   lastChapterRead: Float
+
+  """
+  This will only work if the tracker of the track record supports private tracking
+  """
+  private: Boolean
 
   recordId: Int!
 
   scoreString: String
 
+  """
+  This will only work if the tracker of the track record supports reading dates
+  """
   startDate: LongString
 
   status: Int
 
-  unbind: Boolean
+  unbind: Boolean @deprecated(reason: "Replaced with \"unbindTrack\" mutation, replace with unbindTrack")
 }
 
 type UpdateTrackPayload {
   clientMutationId: String
 
   trackRecord: TrackRecordType
+}
+
+type UpdaterJobsInfoType {
+  finishedJobs: Int!
+
+  isRunning: Boolean!
+
+  skippedCategoriesCount: Int!
+
+  skippedMangasCount: Int!
+
+  totalJobs: Int!
+}
+
+type UpdaterUpdates {
+  categoryUpdates: [CategoryUpdateType!]!
+
+  """
+  The current update status at the time of sending the initial message. Is null for all following messages
+  """
+  initial: LibraryUpdateStatus
+
+  jobsInfo: UpdaterJobsInfoType!
+
+  mangaUpdates: [MangaUpdateType!]!
+
+  """
+  Indicates whether updates have been omitted based on the "maxUpdates" subscription variable. In case updates have been omitted, the "updateStatus" query should be re-fetched.
+  """
+  omittedUpdates: Boolean!
 }
 
 """
@@ -2923,11 +3703,17 @@ input ValidateBackupInput {
 
 type ValidateBackupResult {
   missingSources: [ValidateBackupSource!]!
+
+  missingTrackers: [ValidateBackupTracker!]!
 }
 
 type ValidateBackupSource {
   id: LongString!
 
+  name: String!
+}
+
+type ValidateBackupTracker {
   name: String!
 }
 
@@ -2954,7 +3740,7 @@ enum WebUIInterface {
 }
 
 type WebUIUpdateCheck {
-  channel: String!
+  channel: WebUIChannel!
 
   tag: String!
 
@@ -2962,7 +3748,7 @@ type WebUIUpdateCheck {
 }
 
 type WebUIUpdateInfo {
-  channel: String!
+  channel: WebUIChannel!
 
   tag: String!
 }
@@ -2983,34 +3769,6 @@ type WebUIUpdateStatus {
   progress: Int!
 
   state: UpdateState!
-}
-
-input LoginInput {
-  clientMutationId: String
-
-  username: String!
-
-  password: String!
-}
-
-type LoginPayload {
-  clientMutationId: String
-
-  accessToken: String!
-
-  refreshToken: String!
-}
-
-input RefreshTokenInput {
-  clientMutationId: String
-
-  refreshToken: String!
-}
-
-type RefreshTokenPayload {
-  clientMutationId: String
-
-  accessToken: String!
 }
 
 type __Directive {
@@ -3217,6 +3975,11 @@ type __Type {
 
   ofType: __Type
 
+  """
+  This field is considered experimental because it has not yet been ratified in the graphql specification
+  """
+  isOneOf: Boolean
+
   specifiedByURL: String
 
   specifiedByUrl: String @deprecated(reason: "This legacy name has been replaced by `specifiedByURL`")
@@ -3286,6 +4049,11 @@ directive @deprecated ("The reason for the deprecation" reason: String = "No lon
 Exposes a URL that specifies the behaviour of this scalar.
 """
 directive @specifiedBy ("The URL that specifies the behaviour of this scalar." url: String!) on SCALAR
+
+"""
+Indicates an Input Object is a OneOf Input Object.
+"""
+directive @oneOf on INPUT_OBJECT
 
 schema {
   query: Query

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
@@ -78,6 +78,7 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
 
     override val baseUrl by lazy { getPrefBaseUrl() }
     private val apolloClient = lazy { createApolloClient(checkedBaseUrl) }
+    private val baseAuthMode by lazy { getPrefBaseAuthMode() }
     private val baseLogin by lazy { getPrefBaseLogin() }
     private val basePassword by lazy { getPrefBasePassword() }
 
@@ -644,16 +645,31 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
         }
     }
 
+    private enum class AuthMode(val title: String) {
+        NONE("None"),
+        BASIC_AUTH("Basic Authentication"),
+        SIMPLE_LOGIN("Simple Login"),
+        UI_LOGIN("UI Login"),
+    }
+
     private fun getPrefBaseUrl(): String = preferences.getString(ADDRESS_TITLE, ADDRESS_DEFAULT)!!
-    private fun getPrefBaseLogin(): String = preferences.getString(LOGIN_TITLE, LOGIN_DEFAULT)!!
-    private fun getPrefBasePassword(): String = preferences.getString(PASSWORD_TITLE, PASSWORD_DEFAULT)!!
+    private fun getPrefBaseAuthMode(): AuthMode {
+        if (!preferences.contains(MODE_TITLE) && basePassword.isNotEmpty() && baseLogin.isNotEmpty()) {
+            return AuthMode.BASIC_AUTH
+        }
+        return AuthMode.valueOf(preferences.getString(MODE_TITLE, MODE_DEFAULT)!!)
+    }
+    private fun getPrefBaseLogin(): String = preferences.getString(LOGIN_TITLE, LOGIN_DEFAULT) ?: preferences.getString("Login (Basic Auth)", LOGIN_DEFAULT)!!
+    private fun getPrefBasePassword(): String = preferences.getString(PASSWORD_TITLE, PASSWORD_DEFAULT) ?: preferences.getString("Password (Basic Auth)", PASSWORD_DEFAULT)!!
 
     companion object {
         private const val ADDRESS_TITLE = "Server URL Address"
         private const val ADDRESS_DEFAULT = ""
-        private const val LOGIN_TITLE = "Login (Basic Auth)"
+        private const val MODE_TITLE = "Login Mode"
+        private const val MODE_DEFAULT = "NONE"
+        private const val LOGIN_TITLE = "Login"
         private const val LOGIN_DEFAULT = ""
-        private const val PASSWORD_TITLE = "Password (Basic Auth)"
+        private const val PASSWORD_TITLE = "Password"
         private const val PASSWORD_DEFAULT = ""
     }
 

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
@@ -684,8 +684,8 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
         }
         return AuthMode.valueOf(preferences.getString(MODE_TITLE, MODE_DEFAULT)!!)
     }
-    private fun getPrefBaseLogin(): String = preferences.getString(LOGIN_TITLE, LOGIN_DEFAULT) ?: preferences.getString("Login (Basic Auth)", LOGIN_DEFAULT)!!
-    private fun getPrefBasePassword(): String = preferences.getString(PASSWORD_TITLE, PASSWORD_DEFAULT) ?: preferences.getString("Password (Basic Auth)", PASSWORD_DEFAULT)!!
+    private fun getPrefBaseLogin(): String = preferences.getString(LOGIN_TITLE, null) ?: preferences.getString("Login (Basic Auth)", LOGIN_DEFAULT)!!
+    private fun getPrefBasePassword(): String = preferences.getString(PASSWORD_TITLE, null) ?: preferences.getString("Password (Basic Auth)", PASSWORD_DEFAULT)!!
 
     companion object {
         private const val ADDRESS_TITLE = "Server URL Address"

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
@@ -614,16 +614,16 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
 
     // ------------- Preferences -------------
     override fun setupPreferenceScreen(screen: PreferenceScreen) {
-        screen.addPreference(screen.editTextPreference(ADDRESS_TITLE, ADDRESS_DEFAULT, baseUrl, false, "i.e. http://192.168.1.115:4567"))
-        screen.addPreference(screen.editListPreference(MODE_TITLE, MODE_DEFAULT, baseAuthMode.title, AuthMode.entries.map { it.title }, AuthMode.entries.map { it.toString() }, "Must match Suwayomi's auth_mode setting"))
-        screen.addPreference(screen.editTextPreference(LOGIN_TITLE, LOGIN_DEFAULT, baseLogin, false, ""))
-        screen.addPreference(screen.editTextPreference(PASSWORD_TITLE, PASSWORD_DEFAULT, basePassword, true, ""))
+        screen.addPreference(screen.editTextPreference(ADDRESS_TITLE, ADDRESS_DEFAULT, baseUrl, false, "i.e. http://192.168.1.115:4567", ADDRESS_TITLE))
+        screen.addPreference(screen.editListPreference(MODE_TITLE, MODE_DEFAULT, baseAuthMode.title, AuthMode.entries.map { it.title }, AuthMode.entries.map { it.toString() }, "Must match Suwayomi's auth_mode setting", MODE_TITLE))
+        screen.addPreference(screen.editTextPreference(LOGIN_TITLE, LOGIN_DEFAULT, baseLogin, false, "", LOGIN_KEY))
+        screen.addPreference(screen.editTextPreference(PASSWORD_TITLE, PASSWORD_DEFAULT, basePassword, true, "", PASSWORD_KEY))
     }
 
     /** boilerplate for [EditTextPreference] */
-    private fun PreferenceScreen.editTextPreference(title: String, default: String, value: String, isPassword: Boolean = false, placeholder: String): EditTextPreference {
+    private fun PreferenceScreen.editTextPreference(title: String, default: String, value: String, isPassword: Boolean = false, placeholder: String, key: String): EditTextPreference {
         return EditTextPreference(context).apply {
-            key = title
+            this.key = title
             this.title = title
             summary = value.ifEmpty { placeholder }
             this.setDefaultValue(default)
@@ -637,7 +637,7 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
 
             setOnPreferenceChangeListener { _, newValue ->
                 try {
-                    val res = preferences.edit().putString(title, newValue as String).commit()
+                    val res = preferences.edit().putString(key, newValue as String).commit()
                     Toast.makeText(context, "Restart Tachiyomi to apply new setting.", Toast.LENGTH_LONG).show()
                     res
                 } catch (e: Exception) {
@@ -648,9 +648,9 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
         }
     }
 
-    private fun PreferenceScreen.editListPreference(title: String, default: String, value: String, entries: List<CharSequence>, entryValues: List<CharSequence>, placeholder: String): ListPreference {
+    private fun PreferenceScreen.editListPreference(title: String, default: String, value: String, entries: List<CharSequence>, entryValues: List<CharSequence>, placeholder: String, key: String): ListPreference {
         return ListPreference(context).apply {
-            key = title
+            this.key = title
             this.title = title
             this.entries = entries.toTypedArray()
             this.entryValues = entryValues.toTypedArray()
@@ -659,7 +659,7 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
 
             setOnPreferenceChangeListener { _, newValue ->
                 try {
-                    val res = preferences.edit().putString(title, newValue as String).commit()
+                    val res = preferences.edit().putString(key, newValue as String).commit()
                     Toast.makeText(context, "Restart Tachiyomi to apply new setting.", Toast.LENGTH_LONG).show()
                     res
                 } catch (e: Exception) {
@@ -684,16 +684,18 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
         }
         return AuthMode.valueOf(preferences.getString(MODE_TITLE, MODE_DEFAULT)!!)
     }
-    private fun getPrefBaseLogin(): String = preferences.getString(LOGIN_TITLE, null) ?: preferences.getString("Login (Basic Auth)", LOGIN_DEFAULT)!!
-    private fun getPrefBasePassword(): String = preferences.getString(PASSWORD_TITLE, null) ?: preferences.getString("Password (Basic Auth)", PASSWORD_DEFAULT)!!
+    private fun getPrefBaseLogin(): String = preferences.getString(LOGIN_KEY, LOGIN_DEFAULT)!!
+    private fun getPrefBasePassword(): String = preferences.getString(PASSWORD_KEY, PASSWORD_DEFAULT)!!
 
     companion object {
         private const val ADDRESS_TITLE = "Server URL Address"
         private const val ADDRESS_DEFAULT = ""
         private const val MODE_TITLE = "Login Mode"
         private const val MODE_DEFAULT = "NONE"
+        private const val LOGIN_KEY = "Login (Basic Auth)"
         private const val LOGIN_TITLE = "Login"
         private const val LOGIN_DEFAULT = ""
+        private const val PASSWORD_KEY = "Password (Basic Auth)"
         private const val PASSWORD_TITLE = "Password"
         private const val PASSWORD_DEFAULT = ""
     }

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
@@ -97,7 +97,7 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
             }
         }
 
-        private fun <D : Operation.Data> ApolloResponse<D>.isUnauthorized(): Boolean = this.hasErrors() && this.errors!!.any { it.message.contains("suwayomi.tachidesk.server.user.UnauthorizedException") }
+        private fun <D : Operation.Data> ApolloResponse<D>.isUnauthorized(): Boolean = this.hasErrors() && this.errors!!.any { it.message.contains("suwayomi.tachidesk.server.user.UnauthorizedException") || it.message == "Unauthorized" }
     }
 
     private fun createApolloClient(serverUrl: String): ApolloClient {

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
@@ -182,7 +182,7 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
                 .toFlow()
                 .map {
                     it.dataAssertNoErrors
-                        .fetchManga
+                        .fetchManga!!
                         .manga
                         .mangaFragment
                         .toSManga()
@@ -216,7 +216,7 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
                 .toFlow()
                 .map { response ->
                     response.dataAssertNoErrors
-                        .fetchChapters
+                        .fetchChapters!!
                         .chapters
                         .sortedByDescending { it.chapterFragment.sourceOrder }
                         .map {
@@ -256,7 +256,7 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
                         .toFlow()
                         .map {
                             it.dataAssertNoErrors
-                                .fetchChapterPages
+                                .fetchChapterPages!!
                                 .pages
                                 .mapIndexed { index, url ->
                                     Page(

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/TokenManager.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/TokenManager.kt
@@ -1,0 +1,48 @@
+package eu.kanade.tachiyomi.extension.all.tachidesk
+
+import android.util.Log
+import com.apollographql.apollo3.api.ApolloRequest
+import com.apollographql.apollo3.api.Operation
+import eu.kanade.tachiyomi.network.await
+import okhttp3.FormBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+class TokenManager(private val mode: Tachidesk.AuthMode, private val user: String, private val pass: String, private val baseUrl: String, private val baseClient: OkHttpClient) {
+    private var currentToken: String? = null
+    private var refreshToken: String? = null
+    private var cookies: String = ""
+
+    public fun <D : Operation.Data> ApolloRequest.Builder<D>.addToken(): ApolloRequest.Builder<D> {
+        return when (mode) {
+            Tachidesk.AuthMode.SIMPLE_LOGIN -> this.addHttpHeader("Cookie", cookies)
+            else -> this
+        }
+    }
+
+    public suspend fun refresh() {
+        Log.v(TAG, "Refreshing token for mode $mode")
+        when (mode) {
+            Tachidesk.AuthMode.SIMPLE_LOGIN -> {
+                val formBody = FormBody.Builder().add("user", user).add("pass", pass).build()
+                val request = Request.Builder().url(baseUrl + "/login.html").post(formBody).build()
+                val result = baseClient.newCall(request).await()
+                // login.html redirects when successful
+                if (!result.isRedirect) {
+                    var err = result.body.string().replace(".*<div class=\"error\">([^<]*)</div>.*".toRegex(RegexOption.DOT_MATCHES_ALL)) {
+                        it.groups[1]!!.value
+                    }
+                    Log.v(TAG, "Cookie refresh failed, server did not redirect, error: $err")
+                    throw Exception("Login failed: $err")
+                }
+                cookies = result.header("Set-Cookie", "")!!
+                Log.v(TAG, "Cookie successfully refreshed")
+            }
+            else -> {}
+        }
+    }
+
+    companion object {
+        private const val TAG = "Tachidesk.TokenManger"
+    }
+}

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/TokenManager.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/TokenManager.kt
@@ -61,6 +61,14 @@ class TokenManager(private val mode: Tachidesk.AuthMode, private val user: Strin
         }
     }
 
+    public fun Request.Builder.addToken(): Request.Builder {
+        return when (mode) {
+            Tachidesk.AuthMode.SIMPLE_LOGIN -> this.header("Cookie", cookies)
+            Tachidesk.AuthMode.UI_LOGIN -> this.header("Authorization", "Bearer $currentToken")
+            else -> this
+        }
+    }
+
     public suspend fun refresh(oldToken: Any?) {
         Log.v(TAG, "Refreshing token for mode $mode")
         when (mode) {

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/TokenManager.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/TokenManager.kt
@@ -26,7 +26,7 @@ class TokenManager(private val mode: Tachidesk.AuthMode, private val user: Strin
             Tachidesk.AuthMode.SIMPLE_LOGIN -> {
                 val formBody = FormBody.Builder().add("user", user).add("pass", pass).build()
                 val request = Request.Builder().url(baseUrl + "/login.html").post(formBody).build()
-                val result = baseClient.newCall(request).await()
+                val result = baseClient.newBuilder().followRedirects(false).build().newCall(request).await()
                 // login.html redirects when successful
                 if (!result.isRedirect) {
                     var err = result.body.string().replace(".*<div class=\"error\">([^<]*)</div>.*".toRegex(RegexOption.DOT_MATCHES_ALL)) {

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/TokenManager.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/TokenManager.kt
@@ -43,6 +43,6 @@ class TokenManager(private val mode: Tachidesk.AuthMode, private val user: Strin
     }
 
     companion object {
-        private const val TAG = "Tachidesk.TokenManger"
+        private const val TAG = "Tachidesk.TokenManager"
     }
 }


### PR DESCRIPTION
Implemented as a `ApolloInterceptor`, this PR catches Unauthorized exceptions, performs the relevant login action (`POST` to `login.html` or `Login` mutation), then tries the request again.

This has one problem for the moment, where I want your input:  
Because token refreshes are only handled in Apollo, any request by Mihon/Tachihomi directly using `headersBuilder` may run into expired tokens. For example, when using `UI_LOGIN` with an extremely short token duration (e.g. 10 seconds), Mihon suceeds to load the manga list (in Browse), but refreshing one title fails because the returned token is already expired. I'm not sure how this could be fixed.

As soon as this is done, these changes also need to be upstreamed to the tracker in Mihon.