### PR TITLE
TokenManager: Add credentials for basic auth

### DIFF
--- a/src/all/tachidesk/build.gradle
+++ b/src/all/tachidesk/build.gradle
@@ -7,7 +7,7 @@ ext {
     extName = 'Suwayomi'
     pkgNameSuffix = 'all.tachidesk'
     extClass = '.Tachidesk'
-    extVersionCode = 20
+    extVersionCode = 21
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/TokenManager.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/TokenManager.kt
@@ -63,6 +63,10 @@ class TokenManager(private val mode: Tachidesk.AuthMode, private val user: Strin
 
     public fun Request.Builder.addToken(): Request.Builder {
         return when (mode) {
+            Tachidesk.AuthMode.BASIC_AUTH -> {
+                val credentials = Credentials.basic(user, pass)
+                this.header("Authorization", credentials)
+            }
             Tachidesk.AuthMode.SIMPLE_LOGIN -> this.header("Cookie", cookies)
             Tachidesk.AuthMode.UI_LOGIN -> this.header("Authorization", "Bearer $currentToken")
             else -> this


### PR DESCRIPTION
This is important for the tracker, since it uses this client, and expects that basic auth should work. Before this, we added the basic headers to Apollo, but not to OkHttp (but we added to headersBuilder, which works for the reader, which does not use our client...)

Reported on discord

Checklist:

- [x] Updated `extVersionCode` value in `build.gradle` for individual extensions
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [ ] Added the `isNsfw = true` flag in `build.gradle` when appropriate
- [x] Have not changed source names
- [ ] Have explicitly kept the `id` if a source's name or language were changed
- [x] Have tested the modifications by compiling and running the extension through Android Studio
