### PR TITLE
Handle GQL errors in OkHttp interceptor

### DIFF
--- a/src/all/tachidesk/build.gradle
+++ b/src/all/tachidesk/build.gradle
@@ -7,7 +7,7 @@ ext {
     extName = 'Suwayomi'
     pkgNameSuffix = 'all.tachidesk'
     extClass = '.Tachidesk'
-    extVersionCode = 21
+    extVersionCode = 22
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
@@ -101,7 +101,7 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
             data class Outer(val errors: List<Error>)
 
             return try {
-                val body = json.decodeFromStream<Outer>(this.peekBody(Long.MAX_VALUE).byteStream())
+                val body = this.peekBody(Long.MAX_VALUE).byteStream().use { json.decodeFromStream<Outer>(it) }
                 body.errors.any { it.message.contains("suwayomi.tachidesk.server.user.UnauthorizedException") || it.message == "Unauthorized" }
             } catch (e: Exception) {
                 false

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/TokenManager.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/TokenManager.kt
@@ -22,15 +22,6 @@ class TokenManager(private val mode: Tachidesk.AuthMode, private val user: Strin
 
     private data class TokenTuple(val accessToken: String?, val refreshToken: String?)
 
-    public fun getBasicHeaders(): List<HttpHeader> {
-        val headers = mutableListOf<HttpHeader>()
-        if (mode == Tachidesk.AuthMode.BASIC_AUTH && pass.isNotEmpty() && user.isNotEmpty()) {
-            val credentials = Credentials.basic(user, pass)
-            headers.add(HttpHeader("Authorization", credentials))
-        }
-        return headers.toList()
-    }
-
     public fun getHeaders(): List<HttpHeader> {
         val headers = mutableListOf<HttpHeader>()
         when (mode) {


### PR DESCRIPTION
This allows clients that perform manual GQL requests (like the tracker)
to take advantage of the interceptor
Also removes the Apollo interceptor, since that is now handled by the OkHttp interceptor

Checklist:

- [x] Updated the `extVersionCode` value in `build.gradle`
- [ ] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have tested the modifications by compiling and running the extension through Android Studio
