### PR TITLE
fix Unresolved class issue

### DIFF
--- a/src/all/tachidesk/build.gradle
+++ b/src/all/tachidesk/build.gradle
@@ -7,7 +7,7 @@ ext {
     extName = 'Suwayomi'
     pkgNameSuffix = 'all.tachidesk'
     extClass = '.Tachidesk'
-    extVersionCode = 23
+    extVersionCode = 24
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/GraphQLDto.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/GraphQLDto.kt
@@ -1,0 +1,9 @@
+package eu.kanade.tachiyomi.extension.all.tachidesk
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Error(val message: String)
+
+@Serializable
+data class Outer(val errors: List<Error>)

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
@@ -47,7 +47,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import okhttp3.Dns
@@ -95,12 +94,6 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
 
         private fun Response.isUnauthorized(): Boolean = this.code == 401 || this.isGraphQLUnauthorized()
         private fun Response.isGraphQLUnauthorized(): Boolean {
-            @Serializable
-            data class Error(val message: String)
-
-            @Serializable
-            data class Outer(val errors: List<Error>)
-
             return try {
                 val body = this.peekBody(Long.MAX_VALUE).byteStream().use { json.decodeFromStream<Outer>(it) }
                 body.errors.any { it.message.contains("suwayomi.tachidesk.server.user.UnauthorizedException") || it.message == "Unauthorized" }


### PR DESCRIPTION
Fix Unresolved class issue on Suwayomi-Server and Tachimanga.

Checklist:

- [x] Updated the `extVersionCode` value in `build.gradle`
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have tested the modifications by compiling and running the extension through Android Studio

Error logs:
```
2025-11-09 12:18:02.474 [DefaultDispatcher-worker-9] ERROR suwayomi.tachidesk.graphql.AsDataFetcherResult - asDataFetcherResult: failed due to
kotlin.reflect.jvm.internal.KotlinReflectionInternalError: Unresolved class: class eu.kanade.tachiyomi.extension.all.tachidesk.Tachidesk$OkAuthorizationInterceptor$isGraphQLUnauthorized$Outer (kind = CLASS)
	at kotlin.reflect.jvm.internal.KClassImpl.createSyntheticClassOrFail(KClassImpl.kt:398)
	at kotlin.reflect.jvm.internal.KClassImpl.access$createSyntheticClassOrFail(KClassImpl.kt:57)
	at kotlin.reflect.jvm.internal.KClassImpl$Data.descriptor_delegate$lambda$0(KClassImpl.kt:81)
	at kotlin.reflect.jvm.internal.KClassImpl$Data.accessor$KClassImpl$Data$lambda1(KClassImpl.kt)
	at kotlin.reflect.jvm.internal.KClassImpl$Data$$Lambda$1.invoke(Unknown Source)
	at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke(ReflectProperties.java:70)
	at kotlin.reflect.jvm.internal.ReflectProperties$Val.getValue(ReflectProperties.java:32)
	at kotlin.reflect.jvm.internal.KClassImpl$Data.getDescriptor(KClassImpl.kt:67)
	at kotlin.reflect.jvm.internal.KClassImpl.getDescriptor(KClassImpl.kt:226)
	at kotlin.reflect.jvm.internal.KClassImpl.getDescriptor(KClassImpl.kt:57)
	at kotlin.reflect.full.KClassifiers.createType(KClassifiers.kt:47)
	at kotlin.reflect.jvm.internal.CachesKt.CACHE_FOR_BASE_CLASSIFIERS$lambda$0(caches.kt:37)
	at kotlin.reflect.jvm.internal.CachesKt.accessor$CachesKt$lambda2(caches.kt)
	at kotlin.reflect.jvm.internal.CachesKt$$Lambda$2.invoke(Unknown Source)
	at kotlin.reflect.jvm.internal.ComputableClassValue.computeValue(CacheByClass.kt:49)
	at kotlin.reflect.jvm.internal.ComputableClassValue.computeValue(CacheByClass.kt:46)
	at java.base/java.lang.ClassValue.getFromHashMap(Unknown Source)
	at java.base/java.lang.ClassValue.getFromBackup(Unknown Source)
	at java.base/java.lang.ClassValue.get(Unknown Source)
	at kotlin.reflect.jvm.internal.ClassValueCache.get(CacheByClass.kt:63)
	at kotlin.reflect.jvm.internal.CachesKt.getOrCreateKType(caches.kt:55)
	at kotlin.reflect.jvm.internal.ReflectionFactoryImpl.typeOf(ReflectionFactoryImpl.java:123)
	at kotlin.jvm.internal.Reflection.typeOf(Reflection.java:128)
	at eu.kanade.tachiyomi.extension.all.tachidesk.Tachidesk$OkAuthorizationInterceptor.isGraphQLUnauthorized(Unknown Source)
	at eu.kanade.tachiyomi.extension.all.tachidesk.Tachidesk$OkAuthorizationInterceptor.isUnauthorized(Unknown Source)
	at eu.kanade.tachiyomi.extension.all.tachidesk.Tachidesk$OkAuthorizationInterceptor.intercept(Unknown Source)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
	at eu.kanade.tachiyomi.network.interceptor.CloudflareInterceptor.intercept(CloudflareInterceptor.kt:43)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
	at eu.kanade.tachiyomi.network.interceptor.UserAgentInterceptor.intercept(UserAgentInterceptor.kt:19)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
	at eu.kanade.tachiyomi.network.interceptor.UncaughtExceptionInterceptor.intercept(UncaughtExceptionInterceptor.kt:18)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
	at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:226)
	at okhttp3.internal.connection.RealCall.execute(RealCall.kt:178)
	at com.apollographql.apollo3.network.http.DefaultHttpEngine.execute(Unknown Source)
	at com.apollographql.apollo3.network.http.HttpNetworkTransport$EngineInterceptor.intercept(Unknown Source)
	at com.apollographql.apollo3.network.http.DefaultHttpInterceptorChain.proceed(Unknown Source)
	at com.apollographql.apollo3.network.http.HttpNetworkTransport$execute$1.invokeSuspend(Unknown Source)
	at com.apollographql.apollo3.network.http.HttpNetworkTransport$execute$1.invoke(Unknown Source)
	at com.apollographql.apollo3.network.http.HttpNetworkTransport$execute$1.invoke(Unknown Source)
	at kotlinx.coroutines.flow.SafeFlow.collectSafely(Builders.kt:57)
	at kotlinx.coroutines.flow.AbstractFlow.collect(Flow.kt:226)
	at kotlinx.coroutines.flow.internal.ChannelFlowOperatorImpl.flowCollect(ChannelFlow.kt:191)
	at kotlinx.coroutines.flow.internal.ChannelFlowOperator.collectTo$suspendImpl(ChannelFlow.kt:153)
	at kotlinx.coroutines.flow.internal.ChannelFlowOperator.collectTo(ChannelFlow.kt)
	at kotlinx.coroutines.flow.internal.ChannelFlow$collectToFun$1.invokeSuspend(ChannelFlow.kt:56)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:124)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:820)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
2025-11-09 18:14:07.066 [DefaultDispatcher-worker-13] ERROR suwayomi.tachidesk.graphql.AsDataFetcherResult - asDataFetcherResult: failed due to
kotlin.reflect.jvm.internal.KotlinReflectionInternalError: Unresolved class: class eu.kanade.tachiyomi.extension.all.tachidesk.Tachidesk$OkAuthorizationInterceptor$isGraphQLUnauthorized$Outer (kind = CLASS)
	at kotlin.reflect.jvm.internal.KClassImpl.createSyntheticClassOrFail(KClassImpl.kt:398)
	at kotlin.reflect.jvm.internal.KClassImpl.access$createSyntheticClassOrFail(KClassImpl.kt:57)
	at kotlin.reflect.jvm.internal.KClassImpl$Data.descriptor_delegate$lambda$0(KClassImpl.kt:81)
	at kotlin.reflect.jvm.internal.KClassImpl$Data.accessor$KClassImpl$Data$lambda1(KClassImpl.kt)
	at kotlin.reflect.jvm.internal.KClassImpl$Data$$Lambda$1.invoke(Unknown Source)
	at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke(ReflectProperties.java:70)
	at kotlin.reflect.jvm.internal.ReflectProperties$Val.getValue(ReflectProperties.java:32)
	at kotlin.reflect.jvm.internal.KClassImpl$Data.getDescriptor(KClassImpl.kt:67)
	at kotlin.reflect.jvm.internal.KClassImpl.getDescriptor(KClassImpl.kt:226)
	at kotlin.reflect.jvm.internal.KClassImpl.getDescriptor(KClassImpl.kt:57)
	at kotlin.reflect.full.KClassifiers.createType(KClassifiers.kt:47)
	at kotlin.reflect.jvm.internal.CachesKt.CACHE_FOR_BASE_CLASSIFIERS$lambda$0(caches.kt:37)
	at kotlin.reflect.jvm.internal.CachesKt.accessor$CachesKt$lambda2(caches.kt)
	at kotlin.reflect.jvm.internal.CachesKt$$Lambda$2.invoke(Unknown Source)
	at kotlin.reflect.jvm.internal.ComputableClassValue.computeValue(CacheByClass.kt:49)
	at kotlin.reflect.jvm.internal.ComputableClassValue.computeValue(CacheByClass.kt:46)
	at java.base/java.lang.ClassValue.getFromHashMap(Unknown Source)
	at java.base/java.lang.ClassValue.getFromBackup(Unknown Source)
	at java.base/java.lang.ClassValue.get(Unknown Source)
	at kotlin.reflect.jvm.internal.ClassValueCache.get(CacheByClass.kt:63)
	at kotlin.reflect.jvm.internal.CachesKt.getOrCreateKType(caches.kt:55)
	at kotlin.reflect.jvm.internal.ReflectionFactoryImpl.typeOf(ReflectionFactoryImpl.java:123)
	at kotlin.jvm.internal.Reflection.typeOf(Reflection.java:128)
	at eu.kanade.tachiyomi.extension.all.tachidesk.Tachidesk$OkAuthorizationInterceptor.isGraphQLUnauthorized(Unknown Source)
	at eu.kanade.tachiyomi.extension.all.tachidesk.Tachidesk$OkAuthorizationInterceptor.isUnauthorized(Unknown Source)
	at eu.kanade.tachiyomi.extension.all.tachidesk.Tachidesk$OkAuthorizationInterceptor.intercept(Unknown Source)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
	at eu.kanade.tachiyomi.network.interceptor.CloudflareInterceptor.intercept(CloudflareInterceptor.kt:43)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
	at eu.kanade.tachiyomi.network.interceptor.UserAgentInterceptor.intercept(UserAgentInterceptor.kt:19)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
	at eu.kanade.tachiyomi.network.interceptor.UncaughtExceptionInterceptor.intercept(UncaughtExceptionInterceptor.kt:18)
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
	at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:226)
	at okhttp3.internal.connection.RealCall.execute(RealCall.kt:178)
	at com.apollographql.apollo3.network.http.DefaultHttpEngine.execute(Unknown Source)
	at com.apollographql.apollo3.network.http.HttpNetworkTransport$EngineInterceptor.intercept(Unknown Source)
	at com.apollographql.apollo3.network.http.DefaultHttpInterceptorChain.proceed(Unknown Source)
	at com.apollographql.apollo3.network.http.HttpNetworkTransport$execute$1.invokeSuspend(Unknown Source)
	at com.apollographql.apollo3.network.http.HttpNetworkTransport$execute$1.invoke(Unknown Source)
	at com.apollographql.apollo3.network.http.HttpNetworkTransport$execute$1.invoke(Unknown Source)
	at kotlinx.coroutines.flow.SafeFlow.collectSafely(Builders.kt:57)
	at kotlinx.coroutines.flow.AbstractFlow.collect(Flow.kt:226)
	at kotlinx.coroutines.flow.internal.ChannelFlowOperatorImpl.flowCollect(ChannelFlow.kt:191)
	at kotlinx.coroutines.flow.internal.ChannelFlowOperator.collectTo$suspendImpl(ChannelFlow.kt:153)
	at kotlinx.coroutines.flow.internal.ChannelFlowOperator.collectTo(ChannelFlow.kt)
	at kotlinx.coroutines.flow.internal.ChannelFlow$collectToFun$1.invokeSuspend(ChannelFlow.kt:56)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:124)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:820)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)

```