### PR TITLE
Added option to append source to description

### DIFF
--- a/src/all/tachidesk/build.gradle
+++ b/src/all/tachidesk/build.gradle
@@ -7,7 +7,7 @@ ext {
     extName = 'Suwayomi'
     pkgNameSuffix = 'all.tachidesk'
     extClass = '.Tachidesk'
-    extVersionCode = 26
+    extVersionCode = 27
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/tachidesk/graphql/Manga.graphql
+++ b/src/all/tachidesk/graphql/Manga.graphql
@@ -23,6 +23,10 @@ fragment MangaFragment on MangaType {
     }
     unreadCount
     downloadCount
+    source {
+        displayName
+        id
+    }
 }
 
 mutation GetManga($mangaId: Int!) {

--- a/src/all/tachidesk/graphql/Manga.graphql
+++ b/src/all/tachidesk/graphql/Manga.graphql
@@ -25,7 +25,6 @@ fragment MangaFragment on MangaType {
     downloadCount
     source {
         displayName
-        id
     }
 }
 

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
@@ -896,7 +896,12 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
     private fun MangaFragment.toSManga() = SManga.create().also {
         var desc = description
         if (getPrefMentionSourceInDescription() && source != null) {
-            desc += "\n\n**Source:** ${source.displayName} [${source.id}]"
+            val append = "\n\n**Source:** ${source.displayName} [${source.id}]"
+            if (desc == null) {
+                desc = append
+            } else {
+                desc += append
+            }
         }
         it.url = id.toString()
         it.title = title

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
@@ -766,6 +766,7 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
         screen.addPreference(screen.editTextPreference(PASSWORD_TITLE, PASSWORD_DEFAULT, basePassword, true, "", PASSWORD_KEY))
         screen.addPreference(screen.checkBoxPreference(TRACKER_DELETE_TITLE, TRACKER_DELETE_DEFAULT, "", TRACKER_DELETE_KEY))
         screen.addPreference(screen.checkBoxPreference(FETCH_DATA_FROM_SOURCE_TITLE, FETCH_DATA_FROM_SOURCE_DEFAULT, "", FETCH_DATA_FROM_SOURCE_TITLE))
+        screen.addPreference(screen.checkBoxPreference(MENTION_SOURCE_IN_DESCRIPTION_TITLE, MENTION_SOURCE_IN_DESCRIPTION_DEFAULT, "", MENTION_SOURCE_IN_DESCRIPTION_KEY))
         screen.addPreference(screen.editTextPreference(CUSTOM_HTTP_HEADERS_TITLE, CUSTOM_HTTP_HEADERS_DEFAULT, "", false, "", CUSTOM_HTTP_HEADERS_TITLE, "One per line, e.g.:\nHeader1: value1\nHeader2: value2"))
     }
 
@@ -856,6 +857,7 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
     private fun getPrefBasePassword(): String = preferences.getString(PASSWORD_KEY, PASSWORD_DEFAULT)!!
     private fun getPrefTrackerDelete(): Boolean = preferences.getBoolean(TRACKER_DELETE_KEY, TRACKER_DELETE_DEFAULT)
     private fun fetchDataFromSource(): Boolean = preferences.getBoolean(FETCH_DATA_FROM_SOURCE_TITLE, FETCH_DATA_FROM_SOURCE_DEFAULT)
+    private fun getPrefMentionSourceInDescription(): Boolean = preferences.getBoolean(MENTION_SOURCE_IN_DESCRIPTION_KEY, MENTION_SOURCE_IN_DESCRIPTION_DEFAULT)
     private fun getPrefCustomHttpHeaders(): String = preferences.getString(CUSTOM_HTTP_HEADERS_TITLE, CUSTOM_HTTP_HEADERS_DEFAULT)!!
 
     companion object {
@@ -874,6 +876,9 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
         private const val TRACKER_DELETE_DEFAULT = false
         private const val FETCH_DATA_FROM_SOURCE_TITLE = "Fetch Data From Source"
         private const val FETCH_DATA_FROM_SOURCE_DEFAULT = true
+        private const val MENTION_SOURCE_IN_DESCRIPTION_KEY = "Mention Source in Description"
+        private const val MENTION_SOURCE_IN_DESCRIPTION_TITLE = "Append the original remote source to the end of all manga's descriptions"
+        private const val MENTION_SOURCE_IN_DESCRIPTION_DEFAULT = false
         private const val CUSTOM_HTTP_HEADERS_TITLE = "Custom HTTP headers"
         private const val CUSTOM_HTTP_HEADERS_DEFAULT = ""
 
@@ -889,12 +894,16 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
     // ------------- Util -------------
 
     private fun MangaFragment.toSManga() = SManga.create().also {
+        var desc = description
+        if (getPrefMentionSourceInDescription() && source != null) {
+            desc += "\n\n**Source:** ${source.displayName} [${source.id}]"
+        }
         it.url = id.toString()
         it.title = title
         it.thumbnail_url = "$cleanUrl$thumbnailUrl"
         it.artist = artist
         it.author = author
-        it.description = description
+        it.description = desc
         it.genre = genre.joinToString(", ")
         it.status = when (status) {
             MangaStatus.ONGOING -> SManga.ONGOING

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
@@ -896,7 +896,7 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
     private fun MangaFragment.toSManga() = SManga.create().also {
         var desc = description
         if (getPrefMentionSourceInDescription() && source != null) {
-            val append = "\n\n**Source:** ${source.displayName} [${source.id}]"
+            val append = "\n\n**Source:** ${source.displayName}"
             if (desc == null) {
                 desc = append
             } else {


### PR DESCRIPTION
Checklist:

- [x] Updated the `extVersionCode` value in `build.gradle`
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have tested the modifications by compiling and running the extension through Android Studio

Like we'd discussed in the Discord, here it is!

This PR adds a boolean toggle option (disabled by default, as to not interfere with people's existing setups) which adds the original source to the manga's description.
This is because, when using Suwayomi in Mihon, everything is from the Suwayomi source.
If the Suwayomi server has the same manga from multiple sources, it can be difficult to tell them apart from inside Mihon.
With this option, that is resolved.

For example:

<img width="587" height="867" alt="image" src="https://github.com/user-attachments/assets/563536c2-ec38-4a41-8b2e-5d0c2a5be0db" />

Let me know if you'd like any further changes to be done!