### PR TITLE
Link to original source URL in description 

### DIFF
--- a/src/all/tachidesk/build.gradle
+++ b/src/all/tachidesk/build.gradle
@@ -7,7 +7,7 @@ ext {
     extName = 'Suwayomi'
     pkgNameSuffix = 'all.tachidesk'
     extClass = '.Tachidesk'
-    extVersionCode = 27
+    extVersionCode = 28
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/tachidesk/graphql/Manga.graphql
+++ b/src/all/tachidesk/graphql/Manga.graphql
@@ -25,7 +25,9 @@ fragment MangaFragment on MangaType {
     downloadCount
     source {
         displayName
+        baseUrl
     }
+    url
 }
 
 mutation GetManga($mangaId: Int!) {

--- a/src/all/tachidesk/graphql/Manga.graphql
+++ b/src/all/tachidesk/graphql/Manga.graphql
@@ -25,9 +25,8 @@ fragment MangaFragment on MangaType {
     downloadCount
     source {
         displayName
-        baseUrl
     }
-    url
+    realUrl
 }
 
 mutation GetManga($mangaId: Int!) {

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
@@ -896,7 +896,11 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
     private fun MangaFragment.toSManga() = SManga.create().also {
         var desc = description
         if (getPrefMentionSourceInDescription() && source != null) {
-            val append = "\n\n**Source:** [${source.displayName}]($realUrl)"
+            val append = "\n\n**Source:** " + if (realUrl == null) {
+                source.displayName
+            } else {
+                "[${source.displayName}]($realUrl)"
+            }
             if (desc == null) {
                 desc = append
             } else {

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
@@ -896,7 +896,7 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
     private fun MangaFragment.toSManga() = SManga.create().also {
         var desc = description
         if (getPrefMentionSourceInDescription() && source != null) {
-            val append = "\n\n**Source:** ${source.displayName}"
+            val append = "\n\n**Source:** [${source.displayName}](${source.baseUrl}$url)"
             if (desc == null) {
                 desc = append
             } else {

--- a/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
+++ b/src/all/tachidesk/src/eu/kanade/tachiyomi/extension/all/tachidesk/Tachidesk.kt
@@ -896,7 +896,7 @@ class Tachidesk : ConfigurableSource, UnmeteredSource, HttpSource() {
     private fun MangaFragment.toSManga() = SManga.create().also {
         var desc = description
         if (getPrefMentionSourceInDescription() && source != null) {
-            val append = "\n\n**Source:** [${source.displayName}](${source.baseUrl}$url)"
+            val append = "\n\n**Source:** [${source.displayName}]($realUrl)"
             if (desc == null) {
                 desc = append
             } else {


### PR DESCRIPTION
This PR builds upon my previous one (#40), and turns the mention of the source into an actual clickable link (with markdown).
This is useful in the cases where you want to compare what's coming in from the Suwayomi server vs what's on the actual source.

Checklist:

- [x] Updated the `extVersionCode` value in `build.gradle`
- [x] Referenced all related issues in the PR body (e.g. "Closes #xyz")
- [x] Have tested the modifications by compiling and running the extension through Android Studio

Showcase:

<img width="1080" height="2520" alt="Screenshot_20260630-175614" src="https://github.com/user-attachments/assets/4bde956b-886f-486d-8f78-dc7dd76c685e" />
This↑ link goes to here↓
<img width="1080" height="2264" alt="Screenshot_20260630-175625-414" src="https://github.com/user-attachments/assets/3d4e6adb-4b69-4efa-8248-1dc5f3126915" />


